### PR TITLE
Remove deprecated blocks from formula & add a README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# homebrew-devtools
+Homebrew repository for Orbs command line developer tools (like gamma-cli)
+
+If you find any issues, please open an issue and try to supply a log of your command and a basic outlook at which system you're using and which variables or alterations have you ran your this project with.

--- a/gamma-cli.rb
+++ b/gamma-cli.rb
@@ -10,21 +10,9 @@ class GammaCli < Formula
     url "https://github.com/orbs-network/gamma-cli/releases/download/v0.10.0/gammacli-linux-x86-64-v0.10.0.tar.gz"
     sha256 "816ee6f48f47fbda19f00d503e084b582089fece932e464eabea41a41d3dcf03"
   else
-    ohdie "Your operating system is not supported by this formula, if you feel this is a mistake please contract Orbs"
+    ohdie "Your operating system is not supported by this formula, if you feel this is a mistake please contact Orbs"
   end  
   head "https://github.com/orbs-network/homebrew-devtools"
-
-  devel do
-    if OS.mac?
-      url "https://github.com/orbs-network/gamma-cli/releases/download/v0.10.0/gammacli-mac-v0.10.0.tar.gz"
-      sha256 "8f50a52ab54e16b62d0c0202be3bdb3205e266c787e4a0d08342c2d1885a3155"
-    elsif OS.linux?
-      url "https://github.com/orbs-network/gamma-cli/releases/download/v0.10.0/gammacli-linux-x86-64-v0.10.0.tar.gz"
-      sha256 "816ee6f48f47fbda19f00d503e084b582089fece932e464eabea41a41d3dcf03"
-    else
-      ohdie "Your operating system is not supported by this formula, if you feel this is a mistake please contract Orbs"
-    end  
-  end
   
   def install
     system "mkdir", "-p", bin

--- a/orbs-key-generator.rb
+++ b/orbs-key-generator.rb
@@ -5,11 +5,6 @@ class OrbsKeyGenerator < Formula
   url "https://github.com/orbs-network/orbs-key-generator/releases/download/v0.1.1/orbskeygenerator-mac-v0.1.1.tar.gz"
   sha256 "5d2e979981baa549738d80c45adf0197184ad5848c368eb775eb3338ce1126de"
   head "https://github.com/orbs-network/homebrew-devtools"
-
-  devel do
-    url "https://github.com/orbs-network/orbs-key-generator/releases/download/v0.1.1/orbskeygenerator-mac-v0.1.1.tar.gz"
-    sha256 "5d2e979981baa549738d80c45adf0197184ad5848c368eb775eb3338ce1126de"
-  end
   
   def install
     system "mkdir", "-p", bin


### PR DESCRIPTION
* Removed the deprecated "devel" blocks from formula, see Homebrew/brew#7688
* Added a basic README